### PR TITLE
Check if flag is null or undefined instead of falsy before fallback to default

### DIFF
--- a/src/class/flagshipVisitor/flagshipVisitor.ts
+++ b/src/class/flagshipVisitor/flagshipVisitor.ts
@@ -264,7 +264,8 @@ class FlagshipVisitor extends EventEmitter implements IFlagshipVisitor {
 
     // Check modifications requested (=modificationsRequested) match modifications fetched (=mergedModifications)
     modificationsRequested.forEach((modifRequested) => {
-      if (mergedModifications[modifRequested.key]) {
+      if (typeof mergedModifications[modifRequested.key] !== 'undefined'
+          && mergedModifications[modifRequested.key] !== null) {
         desiredModifications[modifRequested.key] = mergedModifications[modifRequested.key];
       } else {
         const { defaultValue } = modifRequested;


### PR DESCRIPTION
To prevent for flag set to false in flagship to default